### PR TITLE
Correct the filename for initialDoc

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ const App = () => {
     WebViewer(
       {
         path: '/webviewer/lib',
-        initialDoc: '/files/pdftron_about.pdf',
+        initialDoc: '/files/PDFTRON_about.pdf',
       },
       viewer.current,
     ).then((instance) => {


### PR DESCRIPTION
## Preamble

This PR fixes the incorrect capitalization for `initialDoc`, as this does not work in Linux environments

Credit to @0xb1dd1e (#6) for reporting this issue

## Screenshots

```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Raspbian
Description:    Raspbian GNU/Linux 10 (buster)
Release:        10
Codename:       buster
```

### Before

![image](https://user-images.githubusercontent.com/16601729/88323506-30fad000-ccd7-11ea-949e-5942e4363a8b.png)

### After
Tested on f3b902b

```
$ git log --oneline -1
f3b902b (HEAD -> bugfix/filename-capitalization, origin/bugfix/filename-capitalization) Correct the filename for initialDoc
```

![image](https://user-images.githubusercontent.com/16601729/88323434-14f72e80-ccd7-11ea-9595-ca4fe89193f3.png)