### PR TITLE
[Misc] remove strict mode to fix webcompoment load webviewer twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>
   );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
In webcomponent mode, this sample will load webviewer twice. 
To fix this, removed the react strict mode in index.js